### PR TITLE
Fix distance potential for unreachable states

### DIFF
--- a/src/pbrs/potentials/distance.py
+++ b/src/pbrs/potentials/distance.py
@@ -13,8 +13,8 @@ __all__ = ["DistancePotential"]
 class DistancePotential(Potential):
     """Potential Φ(s) = -d(s, goal) where *d* is the shortest-path length.
 
-    If a state is unreachable from any goal, its distance is ∞ and the
-    potential is set to a large negative value (``-max_dist``).
+    States that cannot reach any goal receive a potential of ``-max_dist``
+    (the worst finite distance observed). Terminal states remain at zero.
     """
 
     def __init__(self, mdp: GraphMDP) -> None:
@@ -30,5 +30,6 @@ class DistancePotential(Potential):
     def __call__(self, s: int) -> float:
         d = self._dist.get(s, np.inf)
         if np.isinf(d):
-            return 0.0  # unreachable or fail nodes
-        return -float(d) 
+            # Unreachable states are assigned the worst potential
+            return -float(self._max_dist)
+        return -float(d)

--- a/tests/test_distance_potential.py
+++ b/tests/test_distance_potential.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import networkx as nx
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from pbrs.envs.graph_env import GraphMDP
+from pbrs.potentials.distance import DistancePotential
+
+
+def test_distance_potential_unreachable():
+    g = nx.DiGraph()
+    g.add_edge(0, 1)
+    g.add_node(2)
+    g.add_node(3)  # unreachable non-terminal
+    mdp = GraphMDP(g, goal_nodes=[1], fail_nodes=[2], gamma=0.9)
+    pot = DistancePotential(mdp)
+    assert pot(1) == 0.0
+    assert pot(2) == 0.0  # fail node
+    assert pot(0) == -1.0  # distance 1 to goal
+    assert pot(3) == -1.0  # unreachable uses -max_dist


### PR DESCRIPTION
## Summary
- fix handling of unreachable states in `DistancePotential`
- add regression test covering unreachable case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855901cd360832fac1f72c32b998b8f